### PR TITLE
Allow JSON parser configuration in projects

### DIFF
--- a/MGTwitterEngineGlobalHeader.h
+++ b/MGTwitterEngineGlobalHeader.h
@@ -48,8 +48,13 @@
  target.
 */
 
+#ifndef YAJL_AVAILABLE
 #define YAJL_AVAILABLE 0
+#endif
+
+#ifndef TOUCHJSON_AVAILABLE
 #define TOUCHJSON_AVAILABLE 0
+#endif
 
 #ifndef __MGTWITTERENGINEID__
 #define __MGTWITTERENGINEID__


### PR DESCRIPTION
Simple change to allow project files to include preprocessor rules for JSON library selection. This removes the need to update upstream code for my specific project.
