### PR TITLE
Fixed a bug in the Base64 files

### DIFF
--- a/NSData+Base64.h
+++ b/NSData+Base64.h
@@ -8,8 +8,6 @@
 // Original development by Dave Winer.
 //
 
-#import "MGTwitterEngineGlobalHeader.h"
-
 @interface NSData (Base64)
 
 /*!	@function	+dataWithBase64EncodedString:

--- a/NSData+Base64.m
+++ b/NSData+Base64.m
@@ -32,7 +32,7 @@ static char encodingTable[64] = {
 		unsigned long ixtext = 0;
 		unsigned long lentext = 0;
 		unsigned char ch = 0;
-		unsigned char inbuf[3], outbuf[4];
+		unsigned char inbuf[4], outbuf[3];
 		short i = 0, ixinbuf = 0;
 		BOOL flignore = NO;
 		BOOL flendtext = NO;


### PR DESCRIPTION
There's a bug in the size of buffers in the base64 files. This commit fixes it, and allows the NSData+Base64 files to be used independently of MGTwitterEngine
